### PR TITLE
fix for Ubuntu 14.04 LTS and Travis

### DIFF
--- a/invenio-kickstart
+++ b/invenio-kickstart
@@ -83,7 +83,7 @@ else
 fi
 
 # set up env/opt/home development environment:
-${CFG_INVENIO_SRCDIR}-devscripts/invenio-setup-environment --yes-i-know
+invenio-devscripts/invenio-setup-environment --yes-i-know
 
 # Now we have to reread CFG_INVENIO_* variables set up in the previous
 # step.  Let's use eval here, since e.g. on Ubuntu vagrant box,
@@ -93,9 +93,9 @@ eval $(grep "export CFG_INVENIO" $HOME/.bashrc)
 eval $(grep "export PATH=" $HOME/.bashrc)
 
 # install Apache/MySQL/Python/etc prerequisites:
-${CFG_INVENIO_SRCDIR}-devscripts/invenio-setup-prerequisites --yes-i-know
+invenio-devscripts/invenio-setup-prerequisites --yes-i-know
 
 # install Invenio demo site instance:
-${CFG_INVENIO_SRCDIR}-devscripts/invenio-recreate-demo-site --yes-i-know
+invenio-devscripts/invenio-recreate-demo-site --yes-i-know
 
 # end of file

--- a/invenio-recreate-demo-site
+++ b/invenio-recreate-demo-site
@@ -190,7 +190,7 @@ fi
 
 # update Apache configuration now: (this needs to be done after table
 # creation in the next branch)
-sudo -u $CFG_INVENIO_USER $CFG_INVENIO_PREFIX/bin/inveniocfg --create-apache-conf
+sudo -u $CFG_INVENIO_USER VIRTUAL_ENV=$VIRTUAL_ENV $CFG_INVENIO_PREFIX/bin/inveniocfg --create-apache-conf
 
 # create demo site
 sudo -u $CFG_INVENIO_USER $CFG_INVENIO_PREFIX/bin/inveniocfg --create-demo-site --yes-i-know

--- a/invenio-setup-prerequisites
+++ b/invenio-setup-prerequisites
@@ -128,10 +128,15 @@ debian_install_packages () {
         mysql-server mysql-client gnuplot poppler-utils \
         clisp gettext libapache2-mod-wsgi unzip \
         pdftk html2text giflib-tools pstotext netpbm \
-        sbcl libapache2-mod-xsendfile openoffice.org \
+        sbcl libapache2-mod-xsendfile redis-server \
         automake libmysqlclient-dev libxml2-dev libxslt-dev \
-        make postfix texlive python-libxml2 python-libxslt1 \
-        redis-server
+        make postfix texlive python-libxml2 python-libxslt1
+    # OpenOffice.org has be removed from recent releases
+    if sudo apt-get install -y -s openoffice.org; then
+        sudo apt-get install -y openoffice.org
+    else
+        sudo apt-get install -y libreoffice
+    fi
     # restart Redis explicitly; useful for Travis-CI VMs
     sudo /usr/sbin/service redis-server restart
     # installing libhdf5-dev is OS version dependent:
@@ -140,18 +145,19 @@ debian_install_packages () {
     else
         sudo apt-get install -y libhdf5-serial-dev
     fi
-    # install distribute and pip
-    sudo apt-get remove -y python-setuptools python-pip
-    sudo apt-get install -y curl
-    curl http://python-distribute.org/distribute_setup.py | sudo python
-    sudo easy_install pip==1.3.1
-    # install Python dependencies via pip
+    sudo apt-get install -y python-pip
+    sudo pip install -U pip
     olddir=`pwd`
+    allow="--allow-all-external --allow-unverified gnuplot-py --allow-unverified h5py"
     cd $CFG_INVENIO_SRCDIR
     for reqfile in requirements.txt requirements-extras.txt \
         requirements-flask.txt requirements-flask-ext.txt; do
         if [ -e $reqfile ]; then
-            sudo pip install -r $reqfile
+            if [ "$VIRTUAL_ENV" != "" ]; then
+                pip install -r $reqfile $allow
+            else
+                sudo pip install -r $reqfile $allow
+            fi
         fi
     done
     cd $olddir
@@ -229,9 +235,9 @@ debian_configure_apache () {
         sudo DEBIAN_FRONTEND=noninteractive /usr/sbin/make-ssl-cert \
             /usr/share/ssl-cert/ssleay.cnf /etc/apache2/ssl/apache.pem
     fi
-    if [ ! -L /etc/apache2/sites-available/invenio ]; then
+    if [ ! -L /etc/apache2/sites-available/invenio.conf ]; then
         sudo ln -fs /opt/invenio/etc/apache/invenio-apache-vhost.conf \
-            /etc/apache2/sites-available/invenio
+            /etc/apache2/sites-available/invenio.conf
     fi
     if [ ! -e /opt/invenio/etc/apache/invenio-apache-vhost.conf ]; then
         # create them empty for the time being so that apache would start
@@ -239,9 +245,9 @@ debian_configure_apache () {
         sudo touch /opt/invenio/etc/apache/invenio-apache-vhost.conf
         sudo chown -R www-data.www-data /opt/invenio
     fi
-    if [ ! -L /etc/apache2/sites-available/invenio-ssl ]; then
+    if [ ! -L /etc/apache2/sites-available/invenio-ssl.conf ]; then
         sudo ln -fs /opt/invenio/etc/apache/invenio-apache-vhost-ssl.conf \
-            /etc/apache2/sites-available/invenio-ssl
+            /etc/apache2/sites-available/invenio-ssl.conf
     fi
     if [ ! -e /opt/invenio/etc/apache/invenio-apache-vhost-ssl.conf ]; then
         # create them empty for the time being so that apache would start
@@ -249,10 +255,10 @@ debian_configure_apache () {
         sudo touch /opt/invenio/etc/apache/invenio-apache-vhost-ssl.conf
         sudo chown -R www-data.www-data /opt/invenio
     fi
-    sudo /usr/sbin/a2dissite default
-    sudo /usr/sbin/a2ensite invenio
-    sudo /usr/sbin/a2ensite invenio-ssl
+    sudo /usr/sbin/a2dissite "*default*"
+    sudo /usr/sbin/a2ensite "invenio*"
     sudo /usr/sbin/a2enmod ssl
+    sudo /usr/sbin/a2enmod version || echo ":("
     sudo /usr/sbin/a2enmod xsendfile
     sudo /etc/init.d/apache2 restart
 }


### PR DESCRIPTION
- switches from openoffice.org to libreoffice
- disables 000-default as well as default-ssl using wildcard.
- renames vhost configuration to .conf otherwise a2ensite doesn't see them.
- keeps pip, no downgrading
- fix some path (related to travis)
