### PR TITLE
invenio2-kickstart: fix vagrant url

### DIFF
--- a/README.org
+++ b/README.org
@@ -31,7 +31,7 @@ laptop> cd ~/private/vm/invenio2trusty64
 laptop> vim Vagrantfile # enter following content:
 Vagrant.configure("2") do |config|
   config.vm.box = "trusty64"
-  config.vm.box_url = "http://cloud-images.ubuntu.com/vagrant/trusty/20140813/trusty-server-cloudimg-amd64-vagrant-disk1.box"
+  config.vm.box_url = "http://cloud-images.ubuntu.com/vagrant/trusty/current/trusty-server-cloudimg-amd64-vagrant-disk1.box"
   config.vm.hostname = 'localhost.localdomain'
   config.vm.network :forwarded_port, host: 8080, guest: 8080
   config.vm.network :forwarded_port, host: 8443, guest: 8443

--- a/invenio2-kickstart
+++ b/invenio2-kickstart
@@ -39,7 +39,7 @@
 #   laptop> vim Vagrantfile # enter following content:
 #   Vagrant.configure("2") do |config|
 #     config.vm.box = "trusty64"
-#     config.vm.box_url = "http://cloud-images.ubuntu.com/vagrant/trusty/20140813/trusty-server-cloudimg-amd64-vagrant-disk1.box"
+#     config.vm.box_url = "http://cloud-images.ubuntu.com/vagrant/trusty/current/trusty-server-cloudimg-amd64-vagrant-disk1.box"
 #     config.vm.hostname = 'localhost.localdomain'
 #     config.vm.network :forwarded_port, host: 8080, guest: 8080
 #     config.vm.network :forwarded_port, host: 8443, guest: 8443


### PR DESCRIPTION
- Update in README the url of a vagrant box image to use.

Signed-off-by: Leonard Rossi leonardo.r@cern.ch
