### PR TITLE
Travis CI: initial configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,32 @@
+# Travis CI configuration, testing invenio-kickstart script on an
+# older (hence stable) Invenio 1 release version.
+#
+# Tibor Simko <tibor.simko@cern.ch>
+#
+# Copyright (C) 2015 CERN.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, see <http://www.gnu.org/licenses/>.
+
+notifications:
+  email: false
+
+python:
+  - "2.6"
+
+install:
+  - ./invenio-kickstart maint-1.1 --yes-i-know --yes-i-really-know
+
+script:
+  - sudo -u www-data nosetests /opt/invenio/lib/python/invenio/*_unit_tests.py
+  - sudo -u www-data nosetests /opt/invenio/lib/python/invenio/*_regression_tests.py

--- a/invenio-setup-prerequisites
+++ b/invenio-setup-prerequisites
@@ -6,7 +6,7 @@
 #
 # Tibor Simko <tibor.simko@cern.ch>
 #
-# Copyright (C) 2013, 2014 CERN.
+# Copyright (C) 2013, 2014, 2015 CERN.
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -152,8 +152,9 @@ debian_install_packages () {
     else
         sudo apt-get install -y libhdf5-serial-dev
     fi
-    sudo apt-get install -y python-pip
-    sudo pip install -U pip
+    if ! type pip > /dev/null 2>&1; then
+        sudo apt-get install -y python-pip
+    fi
     olddir=`pwd`
     allow="--allow-all-external --allow-unverified gnuplot-py --allow-unverified h5py"
     cd $CFG_INVENIO_SRCDIR


### PR DESCRIPTION
* Initial configuration for Travis CI, testing the `invenio-kickstart`
  script on latest Invenio 1.1.x.

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>