### PR TITLE
invenio-setup-prerequisites: pyuno for Debian

### DIFF
--- a/invenio-setup-prerequisites
+++ b/invenio-setup-prerequisites
@@ -144,6 +144,10 @@ debian_install_packages () {
     else
         sudo apt-get install -y libreoffice
     fi
+    # python-uno does not always exist, so be gentle:
+    if sudo apt-get install -y -s python-uno; then
+        sudo apt-get install -y python-uno
+    fi
     # restart Redis explicitly; useful for Travis-CI VMs
     sudo /usr/sbin/service redis-server restart
     # installing libhdf5-dev is OS version dependent:


### PR DESCRIPTION
* On most Debian based systems, pyuno exists as `python-uno`.  On Ubuntu
  Trusty, it does not exist anymore for Python-2.7.  So let's install it
  gently, i.e. when we can.  (closes #30)

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>