### PR TITLE
invenio-check-AUTHORS: more false positives

### DIFF
--- a/invenio-check-AUTHORS
+++ b/invenio-check-AUTHORS
@@ -39,6 +39,15 @@ CFG_FALSE_POSITIVES = ['Travis C. Brooks',
                        'valkyrie',
                        'Javier Martin Montull',
                        'Theodoros Theodoropoulos',
+                       'Jaime Garcia',
+                       'Jaime García',
+                       'Kennethhole',
+                       'kneczaj',
+                       'pbroz',
+                       'romanchyla',
+                       'Adrian Tudor Panescu',
+                       'Charalampos Tzovanakis',
+                       'Pedro Gaudêncio',
                        'Wojciech Ziółek']
 
 # go to Invenio source directory:


### PR DESCRIPTION
* Adds more alternative author names to the false positive exception
  list.  The alternative names correspond to Invenio's next branch for
  the forthcoming release of Invenio v2.0.

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>